### PR TITLE
Replace esm module with esm2quinox 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "dm-haiku>=0.0.13",
+    "esm2quinox>=0.1.0",
     "flax>=0.10.2",
     "gemmi>=0.7.0",
     "ipymolstar>=0.0.9",

--- a/src/boltz_binder_design/esm2quinox/__init__.py
+++ b/src/boltz_binder_design/esm2quinox/__init__.py
@@ -1,4 +1,4 @@
-from ._esm2 import ESM2 as ESM2, ESM2Result as ESM2Result, tokenise as tokenise
+from ._esm2 import ESM2 as ESM2, ESM2Result as ESM2Result, tokenise as tokenise, _alphabet as alphabet
 from ._torch2eqx import (
     from_torch as from_torch,
     torch2eqx_esm2 as torch2eqx_esm2,

--- a/src/boltz_binder_design/esm2quinox/__init__.py
+++ b/src/boltz_binder_design/esm2quinox/__init__.py
@@ -1,0 +1,1 @@
+from ._esm2 import ESM2 as ESM2, ESM2Result as ESM2Result, tokenise as tokenise

--- a/src/boltz_binder_design/esm2quinox/__init__.py
+++ b/src/boltz_binder_design/esm2quinox/__init__.py
@@ -1,1 +1,9 @@
 from ._esm2 import ESM2 as ESM2, ESM2Result as ESM2Result, tokenise as tokenise
+from ._torch2eqx import (
+    from_torch as from_torch,
+    torch2eqx_esm2 as torch2eqx_esm2,
+    torch2eqx_layer_norm as torch2eqx_layer_norm,
+    torch2eqx_linear as torch2eqx_linear,
+    torch2eqx_tensor as torch2eqx_tensor,
+    torch2eqx_transformer_layer as torch2eqx_transformer_layer,
+)

--- a/src/boltz_binder_design/esm2quinox/_custom_types.py
+++ b/src/boltz_binder_design/esm2quinox/_custom_types.py
@@ -1,0 +1,7 @@
+from typing import TypeAlias
+
+import numpy as np
+from jaxtyping import Array
+
+
+AnyArray: TypeAlias = np.ndarray | Array

--- a/src/boltz_binder_design/esm2quinox/_esm2.py
+++ b/src/boltz_binder_design/esm2quinox/_esm2.py
@@ -1,0 +1,244 @@
+import equinox as eqx
+import jax
+import jax.lax as lax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+from jaxtyping import Array, ArrayLike, Float, Int, PRNGKeyArray
+
+from ._custom_types import AnyArray
+from ._layer import TransformerLayer
+
+
+@jax.jit
+def _randint(key: PRNGKeyArray, index: Int[ArrayLike, ""], maxval: Int[ArrayLike, ""]):
+    return jr.randint(jr.fold_in(key, index), (), minval=0, maxval=maxval)
+
+
+_alphabet = {
+    "b": 0,  # beginning-of-sequence / 'cls'
+    "p": 1,  # pad
+    "e": 2,  # end-of-sequence
+    "u": 3,  # unknown
+    "L": 4,
+    "A": 5,
+    "G": 6,
+    "V": 7,
+    "S": 8,
+    "E": 9,
+    "R": 10,
+    "T": 11,
+    "I": 12,
+    "D": 13,
+    "P": 14,
+    "K": 15,
+    "Q": 16,
+    "N": 17,
+    "F": 18,
+    "Y": 19,
+    "M": 20,
+    "H": 21,
+    "W": 22,
+    "C": 23,
+    "X": 24,
+    "B": 25,
+    "U": 26,
+    "Z": 27,
+    "O": 28,
+    ".": 29,
+    "-": 30,
+    "1": 31,  # null_1
+    "m": 32,  # mask
+}
+assert len(_alphabet) == max(_alphabet.values()) + 1
+
+
+def tokenise(
+    proteins: list[str], length: None | int = None, key: None | PRNGKeyArray = None
+) -> Int[np.ndarray, "batch length"]:
+    """Tokenises a batch of proteins, each represented as strings. Will include start
+    and stop tokens.
+
+    **Arguments:**
+
+    - `proteins`: a list of proteins, each in FASTA format.
+    - `length`: the length to pad or truncate to. If not passed then defaults to two
+        greater than the maximum length of all `proteins`. (The extra two is to fit the
+        start and stop token.) Padding is always done at the end of the protein;
+        truncation is done randomly along its length.
+    - `key`: a `jax.random.key`; must be provided if truncating due to `length` being
+        shorter than some of the input protein sequences. Truncation is deterministic
+        with respect to this key.
+
+    **Returns:**
+
+    The tokenised sequences.
+
+    !!! Example
+
+        ```python
+        from esm2quinox import tokenise
+        proteins = tokenise(["SPIDERMAN", "FOO"])
+        proteins = tokenise(["SPIDERMAN", "FOO"], length=4, key=jax.random.key(0))
+        ```
+    """
+    if length is None:
+        # +2 for start and stop.
+        length = max(map(len, proteins)) + 2
+    out = np.full((len(proteins), length), _alphabet["p"])
+    for protein_index, protein in enumerate(proteins):
+        protein = f"b{protein.upper()}e"
+        if len(protein) > length:
+            if key is None:
+                raise ValueError(
+                    "Must pass tokenise(..., key=...) when cropping to lengths shorter "
+                    "than the input."
+                )
+            start = _randint(key, protein_index, len(protein) - length + 1)
+            protein = protein[start : start + length]
+        for residue_index, residue in enumerate(protein):
+            out[protein_index, residue_index] = _alphabet[residue]
+    return out
+
+
+class ESM2Result(eqx.Module):
+    """The output result from calling `esm2quinox.ESM2.__call__`. Has the `.hidden`
+    representation from the final layer of the model, and the `.logits` (pre-softmax)
+    from mapping that hidden layers through a prediction head.
+    """
+
+    hidden: Float[Array, "length embed_size"]
+    logits: Float[Array, "length alphabet_size"]
+
+
+class LogitHead(eqx.Module):
+    layer_norm: eqx.nn.LayerNorm
+    linear1: eqx.nn.Linear
+    linear2: eqx.nn.Linear
+
+    def __init__(self, embed_size: int, alphabet_size: int, key: PRNGKeyArray):
+        key1, key2 = jr.split(key)
+        self.layer_norm = eqx.nn.LayerNorm(embed_size)
+        self.linear1 = eqx.nn.Linear(embed_size, embed_size, key=key1)
+        self.linear2 = eqx.nn.Linear(embed_size, alphabet_size, key=key2)
+
+    def __call__(self, hidden: Float[Array, " embed_size"]):
+        x = self.linear1(hidden)
+        x = jax.nn.gelu(x, approximate=False)
+        x = self.layer_norm(x)
+        logits = self.linear2(x)
+        return logits
+
+
+class ESM2(eqx.Module):
+    """The masked language modelling trunk of ESM2."""
+
+    num_layers: int = eqx.field(static=True)
+    embed_size: int = eqx.field(static=True)
+    num_heads: int = eqx.field(static=True)
+    token_dropout: bool = eqx.field(static=True)
+    alphabet: dict[str, int] = eqx.field(static=True)
+
+    layers: TransformerLayer
+    layer_norm: eqx.nn.LayerNorm
+    logit_head: LogitHead
+
+    def __init__(
+        self,
+        num_layers: int,
+        embed_size: int,
+        num_heads: int,
+        token_dropout: bool,
+        key: PRNGKeyArray,
+    ):
+        """**Arguments:**
+
+        - `num_layers`: the number of transformer layers.
+        - `embed_size`: the size of the embedding that is propagated from layer to
+            layer.
+        - `num_heads`: how many heads to use in the multihead attention.
+        - `token_dropout`: whether to scale the input embeddings (before the transformer
+            layers) by the number of mask tokens present. If `False` then the embeddings
+            are left unchanged. If `True` then embeddings are scaled by
+            ```python
+            0.88 / (1 - (number_of_masks / number_of_not_pads))
+            ```
+        - `key`: a random key for initialising each layer.
+        """
+        self.num_layers = num_layers
+        self.embed_size = embed_size
+        self.num_heads = num_heads
+        self.token_dropout = token_dropout
+        self.alphabet = _alphabet.copy()
+
+        keys = jr.split(key, num_layers + 1)
+        layer_keys = keys[:-1]
+        logit_key = keys[-1]
+
+        self.layers = eqx.filter_vmap(TransformerLayer)(
+            embed_size, 4 * embed_size, num_heads, layer_keys
+        )
+        self.layer_norm = eqx.nn.LayerNorm(embed_size)
+        self.logit_head = LogitHead(embed_size, len(self.alphabet), logit_key)
+
+    @property
+    def embedding(self):
+        return eqx.nn.Embedding(
+            num_embeddings=len(self.alphabet),
+            embedding_size=self.embed_size,
+            weight=self.logit_head.linear2.weight,
+        )
+
+    def __call__(self, tokens: str | Int[AnyArray, " length"]) -> ESM2Result:
+        """**Arguments:**
+
+        - `tokens`: the input tokens. May either be a JAX array of shape `(length,)` or
+            (for convenience when hacking around), a raw Python string; in the latter
+            case then it will be tokenised before calling the model.
+
+        If you need to process a batch of data then wrap your model in `jax.vmap`.
+
+        **Returns:**
+
+        An `esm2quinox.ESM2Result` object.
+
+        !!! Example
+
+            ```python
+            proteins = esm2quinox.tokenise(["SPIDERMAN", "SPUDMAN"])
+            out = jax.vmap(model)(proteins)
+            ```
+        """
+        if isinstance(tokens, str):
+            # Make it possible to just call it directly for one-offs.
+            # +2 to handle the beginning-of-sequence and end-of-sequence tokens.
+            [tokens] = tokenise([tokens], length=len(tokens) + 2, key=None)
+            assert type(tokens) is np.ndarray
+        return self._call(tokens)
+
+    @eqx.filter_jit
+    def _call(self, tokens: Int[AnyArray, " length"]) -> ESM2Result:
+        x = jax.vmap(self.embedding)(tokens)
+        is_pad = tokens == _alphabet["p"]
+        not_pad = jnp.logical_not(is_pad)
+        if self.token_dropout:
+            is_mask = tokens == _alphabet["m"]
+            x = jnp.where(is_mask[:, None], 0, x)
+            mask_ratio_train = 0.15 * 0.8
+            mask_ratio_observed = is_mask.sum() / not_pad.sum()
+            factor = (1 - mask_ratio_train) / (1 - mask_ratio_observed)
+            x = x * factor
+        x = jnp.where(not_pad[:, None], x, 0)
+
+        dynamic_layers, static_layer = eqx.partition(self.layers, eqx.is_array)
+
+        def f(x, dynamic_layer):
+            layer = eqx.combine(dynamic_layer, static_layer)
+            x = layer(x, is_pad=is_pad)
+            return x, None
+
+        x, _ = lax.scan(f, x, xs=dynamic_layers)
+        hidden = jax.vmap(self.layer_norm)(x)
+        logits = jax.vmap(self.logit_head)(hidden)
+
+        return ESM2Result(hidden=hidden, logits=logits)

--- a/src/boltz_binder_design/esm2quinox/_esm2.py
+++ b/src/boltz_binder_design/esm2quinox/_esm2.py
@@ -123,13 +123,11 @@ class LogitHead(eqx.Module):
         self.linear2 = eqx.nn.Linear(embed_size, alphabet_size, key=key2)
 
     def __call__(self, hidden: Float[Array, " embed_size"]):
-        def _apply(hidden):
-            x = self.linear1(hidden)
-            x = jax.nn.gelu(x, approximate=False)
-            x = self.layer_norm(x)
-            logits = self.linear2(x)
-            return logits
-        return jax.vmap(_apply)(hidden)
+        x = self.linear1(hidden)
+        x = jax.nn.gelu(x, approximate=False)
+        x = self.layer_norm(x)
+        logits = self.linear2(x)
+        return logits
 
 
 class ESM2(eqx.Module):

--- a/src/boltz_binder_design/esm2quinox/_layer.py
+++ b/src/boltz_binder_design/esm2quinox/_layer.py
@@ -1,0 +1,75 @@
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, Bool, Float, PRNGKeyArray
+
+
+class TransformerLayer(eqx.Module):
+    embed_size: int = eqx.field(static=True)
+    hidden_size: int = eqx.field(static=True)
+    num_heads: int = eqx.field(static=True)
+    attn: eqx.nn.MultiheadAttention
+    rotary_embed: eqx.nn.RotaryPositionalEmbedding
+    layer_norm1: eqx.nn.LayerNorm
+    layer_norm2: eqx.nn.LayerNorm
+    linear1: eqx.nn.Linear
+    linear2: eqx.nn.Linear
+
+    def __init__(
+        self, embed_size: int, hidden_size: int, num_heads: int, key: PRNGKeyArray
+    ):
+        self.embed_size = embed_size
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+
+        key1, key2, key3 = jr.split(key, 3)
+        self.attn = eqx.nn.MultiheadAttention(
+            num_heads,
+            self.embed_size,
+            use_query_bias=True,
+            use_key_bias=True,
+            use_value_bias=True,
+            use_output_bias=True,
+            key=key1,
+        )
+        self.rotary_embed = eqx.nn.RotaryPositionalEmbedding(embed_size // num_heads)
+        self.layer_norm1 = eqx.nn.LayerNorm(self.embed_size)
+        self.layer_norm2 = eqx.nn.LayerNorm(self.embed_size)
+        self.linear1 = eqx.nn.Linear(self.embed_size, self.hidden_size, key=key2)
+        self.linear2 = eqx.nn.Linear(self.hidden_size, self.embed_size, key=key3)
+
+    def __call__(
+        self,
+        x: Float[Array, "length {self.embed_size}"],
+        is_pad: Bool[Array, " length"],
+    ) -> Float[Array, "length {self.embed_size}"]:
+        def process_heads(
+            query_heads: Float[Array, "seq_length num_heads qk_size"],
+            key_heads: Float[Array, "seq_length num_heads qk_size"],
+            value_heads: Float[Array, "seq_length num_heads vo_size"],
+        ) -> tuple[
+            Float[Array, "seq_length num_heads qk_size"],
+            Float[Array, "seq_length num_heads qk_size"],
+            Float[Array, "seq_length num_heads vo_size"],
+        ]:
+            query_heads = jax.vmap(self.rotary_embed, in_axes=1, out_axes=1)(
+                query_heads
+            )
+            key_heads = jax.vmap(self.rotary_embed, in_axes=1, out_axes=1)(key_heads)
+
+            return query_heads, key_heads, value_heads
+
+        length, _ = x.shape
+        [length2] = is_pad.shape
+        assert length == length2
+        mask = jnp.broadcast_to(jnp.logical_not(is_pad), (length, length))
+        y = jax.vmap(self.layer_norm1)(x)
+        y = self.attn(y, y, y, process_heads=process_heads, mask=mask)
+        x = x + y
+        y = jax.vmap(self.layer_norm2)(x)
+        y = jax.vmap(self.linear1)(y)
+        y = jax.nn.gelu(y, approximate=False)
+        y = jax.vmap(self.linear2)(y)
+        x = x + y
+        return x

--- a/src/boltz_binder_design/esm2quinox/_torch2eqx.py
+++ b/src/boltz_binder_design/esm2quinox/_torch2eqx.py
@@ -1,0 +1,236 @@
+import sys
+import types
+from typing import TYPE_CHECKING
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.tree_util as jtu
+import numpy as np
+from jaxtyping import PyTree
+
+from ._esm2 import ESM2
+from ._layer import TransformerLayer
+
+
+if TYPE_CHECKING:
+    import esm
+    import torch
+
+
+def _check_esm(layer_name: str) -> types.ModuleType:
+    try:
+        esm = sys.modules["esm"]
+    except KeyError as e:
+        raise RuntimeError(
+            "The PyTorch layer passed should be an instance of a "
+            f"`{layer_name}`. However, ESM does not appear to be "
+            "imported."
+        ) from e
+    if esm.__version__ not in ("2.0.0", "2.0.1"):
+        raise RuntimeError("`torch2eqx` only suports ESM versions 2.0.0 and 2.0.1.")
+
+    return esm
+
+
+def _assert_no_structs_leaf(xi):
+    assert not isinstance(xi, jax.ShapeDtypeStruct)
+
+
+def _assert_no_structs(x: PyTree):
+    jtu.tree_map(_assert_no_structs_leaf, x)
+
+
+def torch2eqx_tensor(x):
+    return jnp.asarray(np.asarray(x.detach().cpu()))
+
+
+def torch2eqx_linear(torch_linear: "torch.nn.Linear") -> eqx.nn.Linear:  # pyright: ignore
+    def make():
+        return eqx.nn.Linear(
+            torch_linear.in_features, torch_linear.out_features, key=jr.key(0)
+        )
+
+    eqx_linear = jax.eval_shape(make)
+    assert eqx_linear.weight.shape == torch_linear.weight.shape
+    assert eqx_linear.bias.shape == torch_linear.bias.shape
+    eqx_linear = eqx.tree_at(
+        lambda m: (m.weight, m.bias),
+        eqx_linear,
+        (torch2eqx_tensor(torch_linear.weight), torch2eqx_tensor(torch_linear.bias)),
+    )
+    _assert_no_structs(eqx_linear)
+    return eqx_linear
+
+
+def torch2eqx_layer_norm(torch_layer_norm: "torch.nn.LayerNorm") -> eqx.nn.LayerNorm:  # pyright: ignore
+    def make():
+        return eqx.nn.LayerNorm(
+            torch_layer_norm.normalized_shape,
+            eps=torch_layer_norm.eps,
+            use_weight=torch_layer_norm.elementwise_affine,
+            use_bias=torch_layer_norm.elementwise_affine,
+        )
+
+    eqx_layer_norm = jax.eval_shape(make)
+    assert eqx_layer_norm.weight.shape == torch_layer_norm.weight.shape
+    assert eqx_layer_norm.bias.shape == torch_layer_norm.bias.shape
+    eqx_layer_norm = eqx.tree_at(
+        lambda m: (m.weight, m.bias),
+        eqx_layer_norm,
+        (
+            torch2eqx_tensor(torch_layer_norm.weight),
+            torch2eqx_tensor(torch_layer_norm.bias),
+        ),
+    )
+    _assert_no_structs(eqx_layer_norm)
+    return eqx_layer_norm
+
+
+def torch2eqx_transformer_layer(
+    torch_layer: "esm.modules.TransformerLayer",  # pyright: ignore
+) -> TransformerLayer:
+    esm = _check_esm("esm.modules.TransformerLayer")
+
+    if not isinstance(torch_layer, esm.modules.TransformerLayer):
+        raise ValueError(
+            "The PyTorch layer passed should be an instance of a "
+            "`esm.modules.TransformerLayer`."
+        )
+    if torch_layer.self_attn.bias_k is not None:
+        raise ValueError("Only `add_bias_kv=False` is supported.")
+    if not isinstance(torch_layer.final_layer_norm, esm.modules.ESM1bLayerNorm):
+        raise ValueError("Only `use_esm1b_layer_norm=True` is supported.")
+    if not torch_layer.use_rotary_embeddings:
+        raise ValueError("Only `use_rotary_embeddings=True` is supported.")
+
+    def make():
+        return TransformerLayer(
+            embed_size=torch_layer.embed_dim,
+            hidden_size=torch_layer.ffn_embed_dim,
+            num_heads=torch_layer.attention_heads,
+            key=jr.key(0),
+        )
+
+    eqx_layer = jax.eval_shape(make)
+    query_proj = torch2eqx_linear(torch_layer.self_attn.q_proj)
+    key_proj = torch2eqx_linear(torch_layer.self_attn.k_proj)
+    value_proj = torch2eqx_linear(torch_layer.self_attn.v_proj)
+    output_proj = torch2eqx_linear(torch_layer.self_attn.out_proj)
+    layer_norm1 = torch2eqx_layer_norm(torch_layer.self_attn_layer_norm)
+    layer_norm2 = torch2eqx_layer_norm(torch_layer.final_layer_norm)
+    linear1 = torch2eqx_linear(torch_layer.fc1)
+    linear2 = torch2eqx_linear(torch_layer.fc2)
+    eqx_layer = eqx.tree_at(
+        lambda m: (
+            m.attn.query_proj,
+            m.attn.key_proj,
+            m.attn.value_proj,
+            m.attn.output_proj,
+            m.attn.dropout,
+            m.layer_norm1,
+            m.layer_norm2,
+            m.linear1,
+            m.linear2,
+        ),
+        eqx_layer,
+        (
+            query_proj,
+            key_proj,
+            value_proj,
+            output_proj,
+            eqx.nn.Dropout(p=0.0),
+            layer_norm1,
+            layer_norm2,
+            linear1,
+            linear2,
+        ),
+    )
+    _assert_no_structs(eqx_layer)
+    return eqx_layer
+
+
+def _stack(*x):
+    is_arrays = [eqx.is_array(xi) for xi in x]
+    if all(is_arrays):
+        return jnp.stack(x)
+    elif not any(is_arrays):
+        values = set(x)
+        if len(values) == 1:
+            return values.pop()
+        else:
+            assert False
+    else:
+        assert False
+
+
+def torch2eqx_esm2(torch_layer: "esm.ESM2") -> ESM2:  # pyright: ignore
+    esm = _check_esm("esm.ESM2")
+
+    if not isinstance(torch_layer, esm.ESM2):
+        raise ValueError(
+            "The PyTorch layer passed should be an instance of a `esm.ESM2`."
+        )
+
+    def make():
+        return ESM2(
+            num_layers=torch_layer.num_layers,
+            embed_size=torch_layer.embed_dim,
+            num_heads=torch_layer.attention_heads,
+            token_dropout=torch_layer.token_dropout,
+            key=jr.key(0),
+        )
+
+    eqx_layer = jax.eval_shape(make)
+    layers = []
+    for torch_transformer_layer in torch_layer.layers:
+        layers.append(torch2eqx_transformer_layer(torch_transformer_layer))
+    layers = jtu.tree_map(_stack, *layers)
+    layer_norm1 = torch2eqx_layer_norm(torch_layer.emb_layer_norm_after)
+    layer_norm2 = torch2eqx_layer_norm(torch_layer.lm_head.layer_norm)
+    linear1 = torch2eqx_linear(torch_layer.lm_head.dense)
+    # linear2:
+    weight = torch2eqx_tensor(torch_layer.lm_head.weight)
+    bias = torch2eqx_tensor(torch_layer.lm_head.bias)
+    assert eqx_layer.logit_head.linear2.weight.shape == weight.shape
+    assert eqx_layer.logit_head.linear2.bias.shape == bias.shape
+    eqx_layer = eqx.tree_at(
+        lambda m: (
+            m.layers,
+            m.layer_norm,
+            m.logit_head.layer_norm,
+            m.logit_head.linear1,
+            m.logit_head.linear2.weight,
+            m.logit_head.linear2.bias,
+        ),
+        eqx_layer,
+        (layers, layer_norm1, layer_norm2, linear1, weight, bias),
+    )
+    _assert_no_structs(eqx_layer)
+    return eqx_layer
+
+
+def from_torch(torch_esm2: "esm.ESM2") -> ESM2:  # pyright: ignore
+    """Loads an ESM2 model from the equivalent PyTorch model provided by the original
+    `esm` library.
+
+    **Arguments:**
+
+    - `torch_esm`: an `esm.ESM2` PyTorch module.
+
+    **Returns:**
+
+    An `esm2equinox.ESM2` model.
+
+    !!! Example
+
+        ```python
+        import esm  # pip install fair-esm==2.0.0
+        import esm2quinox
+
+        torch_model, _ = esm.pretrained.esm2_t6_8M_UR50D()
+        model = esm2quinox.from_torch(torch_model)
+        ```
+    """
+    return torch2eqx_esm2(torch_esm2)

--- a/src/boltz_binder_design/losses/esmq.py
+++ b/src/boltz_binder_design/losses/esmq.py
@@ -1,0 +1,58 @@
+import jax
+import numpy as np
+from jax import numpy as jnp
+from jaxtyping import Array, Float
+
+from esm2quinox import ESM2
+from ..common import LossTerm, TOKENS
+from esm2quinox._esm2 import _alphabet as ESM_TOKENS
+
+def boltz_to_esm2quinox_matrix():
+    """Converts from standard tokenization (Boltz ... plus two???) to ESM2QUINOX tokenization"""
+    T = np.zeros((len(TOKENS), len(ESM_TOKENS)))
+    for i, tok in enumerate(TOKENS):
+        esm_idx = ESM_TOKENS[tok]
+        T[i, esm_idx] = 1
+    return T
+
+class ESM2PseudoLikelihood(LossTerm):
+    esm: ESM2
+    stop_grad: bool = True
+
+    def __call__(self, seq_standard_tokens: Float[Array, "N 20"], *, key):
+        n = seq_standard_tokens.shape[0]
+        # convert from standard tokenization to ESM tokenization
+        esm_toks_unpadded = seq_standard_tokens @ boltz_to_esm_matrix()
+        # add cls and eos tokens
+        esm_toks = jnp.concatenate(
+            [
+                jax.nn.one_hot([0], 33),
+                esm_toks_unpadded,
+                jax.nn.one_hot([2], 33),
+            ]
+        )
+        # todo: does esm2q use the same tensor format?
+
+
+        def single_ll(index: int):
+            # replace token at index with mask
+            masked_tokens = esm_toks.at[index].set(jax.nn.one_hot(ESM_TOKENS.index("<mask>"), 33))
+            # embed and run ESM
+            embedding = masked_tokens @ self.esm.embedding.weight
+            # set masked token embedding to zero
+            embedding = embedding.at[index].set(0.0)
+            # rescale to account for masking during ESM training
+            mask_ratio_train = 0.15 * 0.8
+            embedding = embedding * ((1 - mask_ratio_train) / (1 - 1/(n+2)))
+            # apply ESM trunk and LM head
+            embedding = self.esm._apply_trunk(embedding, np.ones((n + 2, n + 2)))
+            return jax.nn.log_softmax(self.esm.lm_head(embedding))[index]
+
+        masked_log_likelihoods = jax.vmap(single_ll)(jnp.arange(start = 1, stop = n+1))
+        if self.stop_grad:
+            masked_log_likelihoods = jax.lax.stop_gradient(masked_log_likelihoods)
+        pll =  (masked_log_likelihoods * esm_toks_unpadded).sum(-1).mean()
+        return -pll, {"esm_pll": pll}
+
+
+

--- a/src/boltz_binder_design/losses/esmq.py
+++ b/src/boltz_binder_design/losses/esmq.py
@@ -45,7 +45,7 @@ class ESM2PseudoLikelihood(LossTerm):
             embedding = embedding * ((1 - mask_ratio_train) / (1 - 1/(n+2)))
             # apply ESM trunk and LM head
             embedding = self.esm._apply_trunk(embedding, np.ones(n + 2))
-            return jax.nn.log_softmax(self.esm.logit_head(embedding))[index]
+            return jax.nn.log_softmax(jax.vmap(self.esm.logit_head)(embedding))[index]
 
         masked_log_likelihoods = jax.vmap(single_ll)(jnp.arange(start = 1, stop = n+1))
         if self.stop_grad:


### PR DESCRIPTION
Pulling the JAX esm implementation from https://github.com/patrick-kidger/esm2quinox/

Current status: code runs without obvious errors. 
Todo: 

- [ ] test loading pretrained model
- [ ] check if results are sensible
- [ ] give appropriate credit cf. Apache license 
- [ ] replace original esm module with this one 

